### PR TITLE
Fix stale-branches workflow

### DIFF
--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -4,8 +4,8 @@ name: Stale Branches
 
 on:
   schedule:
-    - cron: '0 21 * * 5'
-    
+#     - cron: '0 21 * * 5'
+    - cron: '* * * * *'
 permissions:
   issues: write
   contents: write
@@ -20,3 +20,8 @@ jobs:
         repo-token: ${{ github.token }}
         compare-branches: 'save'
         days-before-delete: 93
+        days-before-stale: 62
+        comment-updates: false
+        max-issues: false
+        tag-committer: false
+        stale-branch-label: stale branch


### PR DESCRIPTION
<!-- # <img src="https://i.imgur.com/jmWW6Sc.png" alt="drawing" width="60"> Pull Requests Template -->
### 1. What type of PR is this? (check all applicable)
- [x] ♻️ Refactor
- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 👷 Optimization
- [ ] 📝 Documentation Update
- [ ] 🔖 Release
- [ ] 🚩 Other

### 2. Description
<!-- Please do not leave this blank. 
Ex.: This PR [adds/removes/fixes/replaces] this [feature/bug/etc]. -->
Fixes stale-branches workflow to edit the number of days before labeling branches as stale. Currently, the number of days is set to 62, which notifies users that the branches are stale and gives them a good amount of time to decide and do something. 

### 3. Relevant Documents, Websites, & Issue Numbers
<!--
Please use this format to link issue numbers to your pull request either in the pull request's description or in a commit message: Fixes #123 
See here: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
None.

### 4. Mobile & Desktop Screenshots/Recordings
<!-- Visual changes require screenshots -->
<img width="1436" alt="Screen Shot 2022-03-25 at 5 38 42 PM" src="https://user-images.githubusercontent.com/57043165/160204868-a0496849-e9cf-493c-9446-5c8f3fb249d9.png">


### 5. Add tests?
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### 6. Remarks, notes, or any future suggestions?
Currently, this is set to run the workflow every minute as a test. 

### 7. Add to the documentation(s)?
- [ ] 📜 readme
- [ ] 📜 contributing.md
- [x] 📓 docs
- [ ] 📕 storybook
- [ ] 🙅 no documentation needed

### 8. Are there any post-deployment tasks we need to perform? 
I will test the workflow to see if it actually works. If so, I'll create another pull request to set the schedule back to the one we've agreed. 

### 9. What gif best describes this PR or how it makes you feel?
Pretty excited. 
